### PR TITLE
Add TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+type AsyncFunction<T> = (...args: any[]) => Promise<T>;
+
+export default function greenlet<T extends AsyncFunction<U>, U>(fn: T): T;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "source": "greenlet.js",
   "main": "dist/greenlet.js",
   "module": "dist/greenlet.m.js",
+  "types": "./index.d.ts",
   "scripts": {
     "prepare": "microbundle",
     "test": "eslint *.js && npm run -s prepare && karmatic"


### PR DESCRIPTION
This adds IntelliSense and prevents the library consumers from passing synchronous functions.

```js
import greenlet from 'greenlet';

/**
 * Proper async function.
 */
async function add(a: number, b: number) {
  return a + b;
}

/**
 * Synchronous function.
 */
function concat(...words: string[]) {
  return words.join('');
}

greenlet(add)(1, 2);          // OK
greenlet(concat)('oh', 'no'); // Error: Type 'string' is not assignable to type 'Promise<{}>'.
```

<img src="https://user-images.githubusercontent.com/20233319/35476071-07388922-03aa-11e8-96de-65fbd714465b.png" width="420">