### PR TITLE
Add support for Edge, Safari

### DIFF
--- a/greenlet.js
+++ b/greenlet.js
@@ -22,7 +22,8 @@ export default function greenlet(asyncFunction) {
 			d => {
 				postMessage([e.data[0], 0, d], [d].filter(x => (
 					(x instanceof ArrayBuffer) ||
-					(x instanceof MessagePort)
+					(x instanceof MessagePort) ||
+					(self.ImageBitmap && x instanceof ImageBitmap)
 				)));
 			},
 			// error handler - callback(id, ERROR(1), error)
@@ -60,7 +61,7 @@ export default function greenlet(asyncFunction) {
 			worker.postMessage([currentId, args], args.filter(x => (
 				(x instanceof ArrayBuffer) ||
 				(x instanceof MessagePort) ||
-        (createImageBitmap && x instanceof ImageBitmap)
+        (window.createImageBitmap && x instanceof ImageBitmap)
 			)));
 		});
 	};

--- a/greenlet.js
+++ b/greenlet.js
@@ -10,7 +10,7 @@ export default function greenlet(asyncFunction) {
 	const promises = {};
 
 	// Use a data URI for the worker's src. It inlines the target function and an RPC handler:
-	const script = 'data:$$='+asyncFunction+';onmessage='+(e => {
+	const script = '$$='+asyncFunction+';onmessage='+(e => {
 		/* global $$ */
 
 		// Invoking within then() captures exceptions in the supplied async function as rejections
@@ -30,8 +30,7 @@ export default function greenlet(asyncFunction) {
 			er => { postMessage([e.data[0], 1, '' + er]); }
 		);
 	});
-	const blob = new Blob([script]);
-	const workerURL = URL.createObjectURL(blob);
+	const workerURL = URL.createObjectURL(new Blob([script]));
 	// Create an "inline" worker (1:1 at definition time)
 	const worker = new Worker(workerURL);
 
@@ -61,7 +60,7 @@ export default function greenlet(asyncFunction) {
 			worker.postMessage([currentId, args], args.filter(x => (
 				(x instanceof ArrayBuffer) ||
 				(x instanceof MessagePort) ||
-        (window.createImageBitmap && x instanceof ImageBitmap)
+				(self.ImageBitmap && x instanceof ImageBitmap)
 			)));
 		});
 	};

--- a/greenlet.js
+++ b/greenlet.js
@@ -59,7 +59,8 @@ export default function greenlet(asyncFunction) {
 			// The filter is to provide a list of transferables to send zero-copy
 			worker.postMessage([currentId, args], args.filter(x => (
 				(x instanceof ArrayBuffer) ||
-				(x instanceof MessagePort)
+				(x instanceof MessagePort) ||
+        (createImageBitmap && x instanceof ImageBitmap)
 			)));
 		});
 	};

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "eslint": "^4.16.0",
     "eslint-config-developit": "^1.1.1",
     "karmatic": "^1.0.6",
-    "microbundle": "^0.4.3",
-    "webpack": "^4.29.6"
+    "microbundle": "^0.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint": "^4.16.0",
     "eslint-config-developit": "^1.1.1",
     "karmatic": "^1.0.6",
-    "microbundle": "^0.4.3"
+    "microbundle": "^0.4.3",
+    "webpack": "^4.29.6"
   }
 }


### PR DESCRIPTION
Edge throws a SecurityError when the function is inlined. Additionally, Edge doesn't have support for ImageBitmap. I didn't see any reason why the library should support ImageBitmap other than a small performance boost for supported browsers. Supporting Edge, I think, should be more of a priority than a possible performance boost for the other browsers.

Creating a blob object URL for the function will bypass the Edge security monitors and provides the same async/await functionality the library is designed for! This merge would resolve #34 let me know what you think!

Codesandbox link: https://codesandbox.io/s/p5ro71xxpm