### PR TITLE
Add type check for the argument of greenlet

### DIFF
--- a/greenlet.js
+++ b/greenlet.js
@@ -3,6 +3,12 @@
  *  @public
  */
 export default function greenlet(asyncFunction) {
+	// Type checking the argument.
+	const type = typeof asyncFunction;
+	if (type !== 'function') {
+		throw new TypeError('Expected function but recevied ' + type);
+	}
+
 	// A simple counter is used to generate worker-global unique ID's for RPC:
 	let currentId = 0;
 


### PR DESCRIPTION
If the argument that is passed is not a function, after this change `greenlet` would throw a `TypeError`. `greenlet` would not work properly if the argument is not a function and the error would be more obscured.